### PR TITLE
Updated TypeReference object to support nested types to support truly…

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -50,10 +50,8 @@ import org.web3j.abi.datatypes.generated.Uint160;
 import org.web3j.abi.datatypes.primitive.Double;
 import org.web3j.abi.datatypes.primitive.Float;
 import org.web3j.utils.Numeric;
-
 import static org.web3j.abi.DefaultFunctionReturnDecoder.getDataOffset;
 import static org.web3j.abi.TypeReference.makeTypeReference;
-import static org.web3j.abi.Utils.findStructConstructor;
 import static org.web3j.abi.Utils.getSimpleTypeName;
 import static org.web3j.abi.Utils.staticStructNestedPublicFieldsFlatList;
 
@@ -125,6 +123,10 @@ public class TypeDecoder {
 
     public static <T extends Type> T decode(String input, Class<T> type) {
         return decode(input, 0, type);
+    }
+
+    public static <T extends Type> T decode(String input, TypeReference<?> type) throws ClassNotFoundException {
+        return decode(input, 0, ((TypeReference<T>)type).getClassType());
     }
 
     public static Address decodeAddress(String input) {
@@ -373,7 +375,7 @@ public class TypeDecoder {
             final BiFunction<List<T>, String, T> consumer) {
         try {
             Class<T> classType = typeReference.getClassType();
-            Constructor<?> constructor = findStructConstructor(classType);
+            Constructor<?> constructor = Utils.findStructConstructor(classType);
             final int length = constructor.getParameterCount();
             List<T> elements = new ArrayList<>(length);
 
@@ -419,9 +421,15 @@ public class TypeDecoder {
             final TypeReference<T> typeReference, final List<T> parameters) {
         try {
             Class<T> classType = typeReference.getClassType();
-            Constructor ctor = findStructConstructor(classType);
-            ctor.setAccessible(true);
-            return (T) ctor.newInstance(parameters.toArray());
+            Constructor ctor;
+            if(!classType.isAssignableFrom(DynamicStruct.class)) {
+                ctor = Utils.findStructConstructor(classType);
+                ctor.setAccessible(true);
+
+                return (T) ctor.newInstance(parameters.toArray());
+            }
+            else
+                return (T)new DynamicStruct((List<Type>)parameters);
         } catch (ReflectiveOperationException e) {
             throw new UnsupportedOperationException(
                     "Constructor cannot accept" + Arrays.toString(parameters.toArray()), e);
@@ -443,7 +451,7 @@ public class TypeDecoder {
     }
 
     public static <T extends Type> T decodeDynamicStruct(
-            String input, int offset, TypeReference<T> typeReference) {
+            String input, int offset, TypeReference<T> typeReference) throws ClassNotFoundException {
 
         BiFunction<List<T>, String, T> function =
                 (elements, typeName) -> {
@@ -463,87 +471,187 @@ public class TypeDecoder {
             final String input,
             final int offset,
             final TypeReference<T> typeReference,
-            final BiFunction<List<T>, String, T> consumer) {
-        try {
+            final BiFunction<List<T>, String, T> consumer) throws ClassNotFoundException {
+
             final Class<T> classType = typeReference.getClassType();
-            Constructor<?> constructor = findStructConstructor(classType);
-            final int length = constructor.getParameterCount();
-            final Map<Integer, T> parameters = new HashMap<>();
-            int staticOffset = 0;
-            final List<Integer> parameterOffsets = new ArrayList<>();
-            for (int i = 0; i < length; ++i) {
-                final Class<T> declaredField = (Class<T>) constructor.getParameterTypes()[i];
-                final T value;
-                final int beginIndex = offset + staticOffset;
-                if (isDynamic(declaredField)) {
-                    final int parameterOffset =
-                            decodeDynamicStructDynamicParameterOffset(
-                                            input.substring(beginIndex, beginIndex + 64))
-                                    + offset;
-                    parameterOffsets.add(parameterOffset);
-                    staticOffset += 64;
-                } else {
-                    if (StaticStruct.class.isAssignableFrom(declaredField)) {
-                        value =
-                                decodeStaticStruct(
-                                        input.substring(beginIndex),
-                                        0,
-                                        TypeReference.create(declaredField));
-                        staticOffset +=
-                                staticStructNestedPublicFieldsFlatList((Class<Type>) declaredField)
-                                                .size()
-                                        * MAX_BYTE_LENGTH_FOR_HEX_STRING;
-                    } else {
-                        value = decode(input.substring(beginIndex), 0, declaredField);
-                        staticOffset += value.bytes32PaddedLength() * 2;
-                    }
-                    parameters.put(i, value);
-                }
+
+            if(classType.isAssignableFrom(DynamicStruct.class)) {
+                // We handle it dynamically. User has not constructed a class representing their struct but instead we have a DynamicStruct type reference with inner references
+                return decodeDynamicStructElementsWithInnerTypeRefs(classType, input, offset, typeReference, consumer);
             }
-            int dynamicParametersProcessed = 0;
-            int dynamicParametersToProcess =
-                    getDynamicStructDynamicParametersCount(constructor.getParameterTypes());
-            for (int i = 0; i < length; ++i) {
-                final Class<T> declaredField = (Class<T>) constructor.getParameterTypes()[i];
-                if (isDynamic(declaredField)) {
-                    final boolean isLastParameterInStruct =
-                            dynamicParametersProcessed == (dynamicParametersToProcess - 1);
-                    final int parameterLength =
-                            isLastParameterInStruct
-                                    ? input.length()
-                                            - parameterOffsets.get(dynamicParametersProcessed)
-                                    : parameterOffsets.get(dynamicParametersProcessed + 1)
-                                            - parameterOffsets.get(dynamicParametersProcessed);
-                    final Class<T> parameterFromAnnotation =
-                            Utils.extractParameterFromAnnotation(
-                                    constructor.getParameterAnnotations()[i]);
-                    parameters.put(
-                            i,
-                            decodeDynamicParameterFromStruct(
-                                    input,
-                                    parameterOffsets.get(dynamicParametersProcessed),
-                                    parameterLength,
-                                    declaredField,
-                                    parameterFromAnnotation));
-                    dynamicParametersProcessed++;
-                }
+            else {
+                // we handle it the constructor way
+                return decodeDynamicStructElementsWithCtor(classType, input, offset, typeReference, consumer);
             }
 
-            String typeName = getSimpleTypeName(classType);
-
-            final List<T> elements = new ArrayList<>();
-            for (int i = 0; i < length; ++i) {
-                elements.add(parameters.get(i));
-            }
-
-            return consumer.apply(elements, typeName);
-        } catch (ClassNotFoundException e) {
-            throw new UnsupportedOperationException(
-                    "Unable to access parameterized type "
-                            + Utils.getTypeName(typeReference.getType()),
-                    e);
-        }
     }
+
+    private static <T extends Type> T decodeDynamicStructElementsWithInnerTypeRefs(
+            final Class<T> classType,
+            final String input,
+            final int offset,
+            final TypeReference<T> typeReference,
+            final BiFunction<List<T>, String, T> consumer) throws ClassNotFoundException {
+
+        final List<TypeReference<?>> InnerTypes = typeReference.getInnerTypeReferences();
+        final int length = InnerTypes.size();
+        final Map<Integer, T> parameters = new HashMap<>();
+        int staticOffset = 0;
+        final List<Integer> parameterOffsets = new ArrayList<>();
+
+        for (int i = 0; i < length; ++i) {
+            final Class<T> declaredField = (Class<T>) InnerTypes.get(i).getClassType();
+            final T value;
+            final int beginIndex = offset + staticOffset;
+            if (isDynamic(declaredField)) {
+                final int parameterOffset =
+                        decodeDynamicStructDynamicParameterOffset(
+                                input.substring(beginIndex, beginIndex + 64))
+                                + offset;
+                parameterOffsets.add(parameterOffset);
+                staticOffset += 64;
+            } else {
+                if (StaticStruct.class.isAssignableFrom(declaredField)) {
+                    value =
+                            decodeStaticStruct(
+                                    input.substring(beginIndex),
+                                    0,
+                                    TypeReference.create(declaredField));
+                    staticOffset +=
+                            staticStructNestedPublicFieldsFlatList((Class<Type>) declaredField)
+                                    .size()
+                                    * MAX_BYTE_LENGTH_FOR_HEX_STRING;
+                } else {
+                    value = decode(input.substring(beginIndex), 0, declaredField);
+                    staticOffset += value.bytes32PaddedLength() * 2;
+                }
+                parameters.put(i, value);
+            }
+        }
+        int dynamicParametersProcessed = 0;
+
+        List<Class<?>> classes = new ArrayList<>();
+        for(var type : InnerTypes) {
+            classes.add(type.getClassType());
+        }
+
+        int dynamicParametersToProcess = getDynamicStructDynamicParametersCount(classes.toArray(new Class<?>[0]));
+        for (int i = 0; i < length; ++i) {
+            var declaredField = InnerTypes.get(i);
+            if (isDynamic(declaredField.getClassType())) {
+                final boolean isLastParameterInStruct =
+                        dynamicParametersProcessed == (dynamicParametersToProcess - 1);
+                final int parameterLength =
+                        isLastParameterInStruct
+                                ? input.length()
+                                - parameterOffsets.get(dynamicParametersProcessed)
+                                : parameterOffsets.get(dynamicParametersProcessed + 1)
+                                - parameterOffsets.get(dynamicParametersProcessed);
+
+                parameters.put(
+                        i,
+                        decodeDynamicParameterFromStruct(
+                                input,
+                                parameterOffsets.get(dynamicParametersProcessed),
+                                parameterLength,
+                                declaredField,
+                                null));
+                dynamicParametersProcessed++;
+            }
+        }
+
+        String typeName = getSimpleTypeName(classType);
+
+        final List<T> elements = new ArrayList<>();
+        for (int i = 0; i < length; ++i) {
+            elements.add(parameters.get(i));
+        }
+
+        return consumer.apply(elements, typeName);
+
+    }
+
+
+    private static <T extends Type> T decodeDynamicStructElementsWithCtor(
+            final Class<T> classType,
+            final String input,
+            final int offset,
+            final TypeReference<T> typeReference,
+            final BiFunction<List<T>, String, T> consumer) throws ClassNotFoundException {
+        Constructor<?> constructor = Utils.findStructConstructor(classType);
+        final int length = constructor.getParameterCount();
+        final Map<Integer, T> parameters = new HashMap<>();
+        int staticOffset = 0;
+        final List<Integer> parameterOffsets = new ArrayList<>();
+        for (int i = 0; i < length; ++i) {
+            final Class<T> declaredField = (Class<T>) constructor.getParameterTypes()[i];
+            final T value;
+            final int beginIndex = offset + staticOffset;
+            if (isDynamic(declaredField)) {
+                final int parameterOffset =
+                        decodeDynamicStructDynamicParameterOffset(
+                                input.substring(beginIndex, beginIndex + 64))
+                                + offset;
+                parameterOffsets.add(parameterOffset);
+                staticOffset += 64;
+            } else {
+                if (StaticStruct.class.isAssignableFrom(declaredField)) {
+                    value =
+                            decodeStaticStruct(
+                                    input.substring(beginIndex),
+                                    0,
+                                    TypeReference.create(declaredField));
+                    staticOffset +=
+                            staticStructNestedPublicFieldsFlatList((Class<Type>) declaredField)
+                                    .size()
+                                    * MAX_BYTE_LENGTH_FOR_HEX_STRING;
+                } else {
+                    value = decode(input.substring(beginIndex), 0, declaredField);
+                    staticOffset += value.bytes32PaddedLength() * 2;
+                }
+                parameters.put(i, value);
+            }
+        }
+        int dynamicParametersProcessed = 0;
+        int dynamicParametersToProcess =
+                getDynamicStructDynamicParametersCount(constructor.getParameterTypes());
+        for (int i = 0; i < length; ++i) {
+            final Class<T> declaredField = (Class<T>) constructor.getParameterTypes()[i];
+            if (isDynamic(declaredField)) {
+                final boolean isLastParameterInStruct =
+                        dynamicParametersProcessed == (dynamicParametersToProcess - 1);
+                final int parameterLength =
+                        isLastParameterInStruct
+                                ? input.length()
+                                - parameterOffsets.get(dynamicParametersProcessed)
+                                : parameterOffsets.get(dynamicParametersProcessed + 1)
+                                - parameterOffsets.get(dynamicParametersProcessed);
+                final Class<T> parameterFromAnnotation =
+                        Utils.extractParameterFromAnnotation(
+                                constructor.getParameterAnnotations()[i]);
+                parameters.put(
+                        i,
+                        decodeDynamicParameterFromStruct(
+                                input,
+                                parameterOffsets.get(dynamicParametersProcessed),
+                                parameterLength,
+                                declaredField,
+                                parameterFromAnnotation));
+                dynamicParametersProcessed++;
+            }
+        }
+
+        String typeName = getSimpleTypeName(classType);
+
+        final List<T> elements = new ArrayList<>();
+        for (int i = 0; i < length; ++i) {
+            elements.add(parameters.get(i));
+        }
+
+        return consumer.apply(elements, typeName);
+
+    }
+
 
     @SuppressWarnings("unchecked")
     private static <T extends Type> int getDynamicStructDynamicParametersCount(
@@ -555,8 +663,37 @@ public class TypeDecoder {
             final String input,
             final int parameterOffset,
             final int parameterLength,
+            final TypeReference<?> declaredField,
+            final Class<T> parameter) throws ClassNotFoundException {
+        final String dynamicElementData =
+                input.substring(parameterOffset, parameterOffset + parameterLength);
+
+        final T value;
+        if (DynamicStruct.class.isAssignableFrom(declaredField.getClassType())) {
+            value = decodeDynamicStruct(dynamicElementData, 0, (TypeReference<? extends T>) declaredField);
+        } else if (DynamicArray.class.isAssignableFrom(declaredField.getClassType())) {
+            if (parameter == null) {
+                throw new RuntimeException(
+                        "parameter can not be null, try to use annotation @Parameterized to specify the parameter type");
+            }
+            value =
+                    (T)
+                            decodeDynamicArray(
+                                    dynamicElementData,
+                                    0,
+                                    Utils.getDynamicArrayTypeReference(parameter));
+        } else {
+            value = decode(dynamicElementData, declaredField);
+        }
+        return value;
+    }
+
+    private static <T extends Type> T decodeDynamicParameterFromStruct(
+            final String input,
+            final int parameterOffset,
+            final int parameterLength,
             final Class<T> declaredField,
-            final Class<T> parameter) {
+            final Class<T> parameter) throws ClassNotFoundException {
         final String dynamicElementData =
                 input.substring(parameterOffset, parameterOffset + parameterLength);
 

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -14,10 +14,13 @@ package org.web3j.abi;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.web3j.abi.datatypes.AbiTypes;
+import org.web3j.abi.datatypes.Array;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.StaticArray;
 
@@ -39,8 +42,15 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     private final Type type;
     private final boolean indexed;
 
+    private List<TypeReference<?>> innerTypes;
+
     protected TypeReference() {
         this(false);
+    }
+
+    protected TypeReference(List<TypeReference<?>> innerTypeReferences) {
+        this(false);
+        innerTypes = innerTypeReferences;
     }
 
     protected TypeReference(boolean indexed) {
@@ -61,6 +71,19 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
      */
     TypeReference getSubTypeReference() {
         return null;
+    }
+
+    public List<TypeReference<?>> getInnerTypeReferences() {
+        return innerTypes;
+    }
+
+    public List<TypeReference<?>> addInnerTypeReferences(TypeReference<?> typeReference) {
+        if(innerTypes == null) {
+            innerTypes = new ArrayList<>();
+        }
+
+        innerTypes.add(typeReference);
+        return innerTypes;
     }
 
     public int compareTo(TypeReference<T> o) {

--- a/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class DynamicStruct extends DynamicArray<Type> implements StructType {
 
-    private final List<Class<Type>> itemTypes = new ArrayList<>();
+    public final List<Class<Type>> itemTypes = new ArrayList<>();
 
     public DynamicStruct(List<Type> values) {
         this(Type.class, values);

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -14,22 +14,11 @@ package org.web3j.abi;
 
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 
-import org.web3j.abi.datatypes.Address;
-import org.web3j.abi.datatypes.Bool;
-import org.web3j.abi.datatypes.DynamicArray;
-import org.web3j.abi.datatypes.DynamicBytes;
-import org.web3j.abi.datatypes.DynamicStruct;
-import org.web3j.abi.datatypes.Function;
-import org.web3j.abi.datatypes.StaticStruct;
-import org.web3j.abi.datatypes.Type;
-import org.web3j.abi.datatypes.Uint;
-import org.web3j.abi.datatypes.Utf8String;
+import org.web3j.abi.datatypes.*;
 import org.web3j.abi.datatypes.generated.Bytes10;
 import org.web3j.abi.datatypes.generated.Uint256;
 import org.web3j.abi.datatypes.generated.Uint32;
@@ -67,6 +56,49 @@ public class DefaultFunctionEncoderTest {
                         Arrays.asList(
                                 new AbiV2TestFixture.ArrayStruct(
                                         BigInteger.ONE, Collections.emptyList()))));
+    }
+
+    @Test
+    public void testDynamicStructFix() throws ClassNotFoundException {
+        // Return data from 'testInputAndOutput' function of this contract https://sepolia.etherscan.io/address/0x009C10396226ECFE3E39b3f1AEFa072E37578e30#readContract
+        String returnedData = "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000000b76616c75656265666f72650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000001320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000063078313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a76616c7565616674657200000000000000000000000000000000000000000000";
+
+        List<TypeReference<?>> MyStruct2Types = new ArrayList<>();
+        List<TypeReference<?>> MyStructTypes = new ArrayList<>();
+        List<TypeReference<?>> MyParamaters = new ArrayList<>();
+
+        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
+        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
+
+        MyStructTypes.add(TypeReference.makeTypeReference("uint256"));
+        MyStructTypes.add(TypeReference.makeTypeReference("string"));
+        MyStructTypes.add(TypeReference.makeTypeReference("string"));
+        MyStructTypes.add(new TypeReference<DynamicStruct>(MyStruct2Types){});
+
+        MyParamaters.add(TypeReference.makeTypeReference("string"));
+        MyParamaters.add(new TypeReference<DynamicStruct>(MyStructTypes){});
+
+        MyParamaters.add(TypeReference.makeTypeReference("string"));
+
+        List<Type> decodedData = FunctionReturnDecoder.decode(returnedData, Utils.convert(MyParamaters));
+
+        assertEquals(decodedData.get(0).getValue(), "valuebefore");
+
+        List<Type> structData = ((DynamicStruct) decodedData.get(1)).getValue();
+
+        assertEquals(structData.get(0).getValue(), BigInteger.valueOf(1));
+        assertEquals(structData.get(1).getValue(), "2");
+        assertEquals(structData.get(2).getValue(), "3");
+
+        List<Type> innerStructData = ((DynamicStruct) structData.get(3)).getValue();
+
+        assertEquals(innerStructData.get(0).getValue(), "1234");
+        assertEquals(innerStructData.get(1).getValue(), "0x1234");
+
+
+        assertEquals(decodedData.get(2).getValue(), "valueafter");
+
+
     }
 
     @Test


### PR DESCRIPTION


### What does this PR do?
This PR adds support for decoding dynamic structs without the need for a class extending DynamicStructs to be added at compile time. 

I have extended the TypeReference class to have nested innerType's which means you can represent a Struct using TypeReference. 

### Where should the reviewer start?
- Look at the TypeReference.java changes to see the innerTypes which have been added. 
- Check the decodeDynamicStruct function in TypeDecoder.java. I have kept the current decoding method intact but renamed it decodeDynamicStructElementsWithCtor and created a new function called decodeDynamicStructElementsWithInnerTypeRefs which is a duplicate of the original function but it has been modified to support the nested type refereces. 
- Check the unit test testDynamicStructFix() in the DefaultFunctionEncoderTest.java which demonstrates how it is expected to be used. 

### Why is it needed?
There needs to be a way to decode dynamic structs without having to create a corresponding class in the project. This allows for the ability to interact with any contract dynamically based on user inputs. 

## Checklist

- [ ] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.