### PR TITLE
Fix two typos in package org.web3j.abi.

### DIFF
--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -62,7 +62,7 @@ import static org.web3j.abi.Utils.staticStructNestedPublicFieldsFlatList;
  * documented, but is the reverse of the encoding details located <a
  * href="https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI">here</a>.
  *
- * <p>The public API is composed of "decode*" methods and provides backward-compatbility. See
+ * <p>The public API is composed of "decode*" methods and provides backward-compatibility. See
  * https://github.com/web3j/web3j/issues/1591 for a discussion about decoding and possible
  * improvements.
  */

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -64,7 +64,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     }
 
     public int compareTo(TypeReference<T> o) {
-        // taken from the blog post comments - this results in an errror if the
+        // taken from the blog post comments - this results in an error if the
         // type parameter is left out.
         return 0;
     }


### PR DESCRIPTION
### What does this PR do?
Fix two typos in package org.web3j.abi.
`compatbility` => `compatibility`
`errror` => `error`

### Why is it needed?
Improves readability