### PR TITLE
Upgrade gradle to v8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'idea'
     id 'org.sonarqube' version '3.4.0.2513'
     id 'jacoco'
-    id 'com.diffplug.gradle.spotless' version '4.5.1'
+    id 'com.diffplug.spotless' version '6.16.0'
     id 'io.codearte.nexus-staging' version '0.22.0'
     id 'de.marcphilipp.nexus-publish' version '0.4.0'
     id 'de.undercouch.download' version '4.1.1'

--- a/gradle/jacoco/build.gradle
+++ b/gradle/jacoco/build.gradle
@@ -14,9 +14,9 @@ jacocoTestReport {
     }
     dependsOn test
     reports {
-        xml.enabled true
-        html.enabled false
-        csv.enabled false
+        xml.required = true
+        html.required = false
+        csv.required = false
         xml.destination file("${buildDir}/reports/jacoco.xml")
     }
 }

--- a/gradle/spotless/build.gradle
+++ b/gradle/spotless/build.gradle
@@ -1,5 +1,5 @@
 
-apply plugin: 'com.diffplug.gradle.spotless'
+apply plugin: 'com.diffplug.spotless'
 apply plugin: "de.undercouch.download"
 
 task downloadJavaLicense(type: Download) {
@@ -39,7 +39,7 @@ spotless {
             exclude '**/.gradle/**'
             exclude '**/build/install/**'
         }
-        ktlint('0.31.0')
+        ktlint('0.47.0')
         trimTrailingWhitespace()
         endWithNewline()
         licenseHeaderFile "$rootDir/gradle/spotless/java.license"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### What does this PR do?
Fixes #2043 
Upgrades gradle to v8.0 and required upgrades to spotless and jacoco.

### Where should the reviewer start?
The gradle wrapper, followed by the `build.gradle` files.

### Why is it needed?
Upgrading a project to a Java version which requires a Gradle version >= 8.0 results in the deprecated method `setOutputDir` being removed which is used when generating java contract wrapper.

I tested this locally in a project using gradle v7.6 and v8.5.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.