### PR TITLE
Fixed DefaultFunctionEncoder calculating offset for nested StaticArray

### DIFF
--- a/abi/src/main/java/org/web3j/abi/DefaultFunctionEncoder.java
+++ b/abi/src/main/java/org/web3j/abi/DefaultFunctionEncoder.java
@@ -99,7 +99,7 @@ public class DefaultFunctionEncoder extends FunctionEncoder {
                             ((StaticArray) type).getComponentType())) {
                 count++;
             } else if (type instanceof StaticArray) {
-                count += ((StaticArray) type).getValue().size();
+                count += getLength(((StaticArray) type).getValue());
             } else {
                 count++;
             }


### PR DESCRIPTION
### What does this PR do?
This PR fixed DefaultFunctionEncoder calculates offset for nested StaticStruct.
That's the problem that's bothering me right now.
See [issue-2052](https://github.com/hyperledger/web3j/issues/2052) for details

### Where should the reviewer start?
Look at the getLength function of DefaultFunctionEncoder.java changes.

### Why is it needed?
In slightly complex nested structures, calculate offset via getLength is incorrect. This is a bug that needs to be fixed.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.