### PR TITLE
Remove registration of bouncy castle as JCE provider

### DIFF
--- a/crypto/src/main/java/org/web3j/crypto/Keys.java
+++ b/crypto/src/main/java/org/web3j/crypto/Keys.java
@@ -19,7 +19,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 
@@ -40,12 +39,7 @@ public class Keys {
     public static final int ADDRESS_LENGTH_IN_HEX = ADDRESS_SIZE >> 2;
     static final int PUBLIC_KEY_LENGTH_IN_HEX = PUBLIC_KEY_SIZE << 1;
     public static final int PRIVATE_KEY_LENGTH_IN_HEX = PRIVATE_KEY_SIZE << 1;
-
-    static {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-    }
+    private static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
 
     private Keys() {}
 
@@ -68,7 +62,7 @@ public class Keys {
                     NoSuchAlgorithmException,
                     InvalidAlgorithmParameterException {
 
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", "BC");
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("ECDSA", BC_PROVIDER);
         ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp256k1");
         if (random != null) {
             keyPairGenerator.initialize(ecGenParameterSpec, random);


### PR DESCRIPTION
### What does this PR do?
This PR removes static registration of `BouncyCastleProvider` as a JCE provider.

### Where should the reviewer start?
In `Keys.java`, review the change for key pair generation to refer to `BouncyCastleProvider` by reference instead of by string.

### Why is it needed?
It prevents the usage of the `Keys` class from inadvertently changing the behavior of the depending application.

## Checklist

- [ x ] I've read the contribution guidelines.
- [  ] I've added tests (if applicable). (I am assuming that additional tests are not required because `Keys` is already well-tested)
- [  ] I've added a changelog entry if necessary.