### PR TITLE
Document the minimum required Java version for the target project to use Web3j as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Java:
 </dependency>
 ```
 
+**Note:** The Web3j Java binaries are compiled using Java 17. Java 17 or a more recent version is required to use Web3j
+ as a dependency.
+
 Android:
 
 ```xml


### PR DESCRIPTION
### What does this PR do?
This PR documents the minimum required Java version for the target project to use Web3j as a dependency

### Where should the reviewer start?
Relevant to the PR:

the current java version that is used for compilation:

https://github.com/hyperledger/web3j/blob/main/gradle/java/build.gradle
Somewhat relevant issue: https://github.com/hyperledger/web3j/issues/2069

### Why is it needed?

Users might encounter errors because Web3j doesn't compile with their project before they realize that the required version should be at least Java 17.

I think it will be beneficial for users to see the required Java version in the README, so they don't spend time digging into the Gradle parameters or troubleshooting issues while building their projects.


## Checklist

- [x] I've read the contribution guidelines.
- not applicable: I've added tests (if applicable).
- IMO a too smal change for a changelog entry. I've added a changelog entry if necessary.