### PR TITLE
Updated TypeReference and TypeDecoder to support decoding of dynamic structs and dynamic struct arrays without a priori Class definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * bump snapshot version to 4.12.1 [#2058](https://github.com/hyperledger/web3j/pull/2058)
 * Update maintainer requirements status [#2064](https://github.com/hyperledger/web3j/pull/2064)
+* Add struct support in java without the need of having a corresponding Java class [#2076](https://github.com/hyperledger/web3j/pull/2076)
 
 ### BREAKING CHANGES
 

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -396,7 +396,8 @@ public class TypeDecoder {
             return 1;
         } catch (ClassNotFoundException e) {
             throw new UnsupportedOperationException(
-                    "countNestedFields failed for " + Utils.getTypeName(typeReference.getType()), e);
+                    "countNestedFields failed for " + Utils.getTypeName(typeReference.getType()),
+                    e);
         }
     }
 

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -470,18 +470,18 @@ public class TypeDecoder {
                     if (elements.isEmpty()) {
                         throw new UnsupportedOperationException(
                                 "Zero length fixed array is invalid type");
-                    } else {
-                        return instantiateStruct(typeReference, elements);
                     }
+
+                    return instantiateStruct(typeReference, elements);
                 };
 
         if (typeReference.getClassType().isAssignableFrom(DynamicStruct.class)
                 && typeReference.getInnerTypes() != null) {
             return decodeDynamicStructElementsFromInnerTypes(
                     input, offset, typeReference, function);
-        } else {
-            return decodeDynamicStructElements(input, offset, typeReference, function);
         }
+
+        return decodeDynamicStructElements(input, offset, typeReference, function);
     }
 
     @SuppressWarnings("unchecked")

--- a/abi/src/main/java/org/web3j/abi/TypeDecoder.java
+++ b/abi/src/main/java/org/web3j/abi/TypeDecoder.java
@@ -385,18 +385,18 @@ public class TypeDecoder {
     }
 
     // Counts the number of nested fields in a StaticStruct with inner types.
-    private static <T extends Type> int numNestedFields(final TypeReference<T> typeReference) {
+    private static <T extends Type> int countNestedFields(final TypeReference<T> typeReference) {
         try {
             if (StaticStruct.class.isAssignableFrom(typeReference.getClassType())) {
                 return typeReference.getInnerTypes().stream()
-                        .map((tr) -> numNestedFields(tr))
+                        .map((tr) -> countNestedFields(tr))
                         .reduce(0, (a, b) -> a + b);
             }
 
             return 1;
         } catch (ClassNotFoundException e) {
             throw new UnsupportedOperationException(
-                    "numNestedFields failed for " + Utils.getTypeName(typeReference.getType()), e);
+                    "countNestedFields failed for " + Utils.getTypeName(typeReference.getType()), e);
         }
     }
 
@@ -416,7 +416,7 @@ public class TypeDecoder {
                 final Class<T> declaredField = innerType.getClassType();
 
                 if (StaticStruct.class.isAssignableFrom(declaredField)) {
-                    final int nestedStructLength = numNestedFields(innerType) * 64;
+                    final int nestedStructLength = countNestedFields(innerType) * 64;
                     value =
                             decodeStaticStruct(
                                     input.substring(currOffset, currOffset + nestedStructLength),
@@ -587,7 +587,7 @@ public class TypeDecoder {
             } else {
                 if (StaticStruct.class.isAssignableFrom(declaredField)) {
                     value = decodeStaticStruct(input.substring(beginIndex), 0, innerType);
-                    tracker.staticOffset += numNestedFields(innerType) * 64;
+                    tracker.staticOffset += countNestedFields(innerType) * 64;
                 } else {
                     value = decode(input.substring(beginIndex), 0, declaredField);
                     tracker.staticOffset += value.bytes32PaddedLength() * 2;
@@ -906,7 +906,7 @@ public class TypeDecoder {
                                             currOffset,
                                             (TypeReference<T>) typeReference.getSubTypeReference());
                             currOffset +=
-                                    numNestedFields(typeReference.getSubTypeReference())
+                                    countNestedFields(typeReference.getSubTypeReference())
                                             * MAX_BYTE_LENGTH_FOR_HEX_STRING;
                         } else {
                             value =

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -14,10 +14,13 @@ package org.web3j.abi;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.web3j.abi.datatypes.AbiTypes;
+import org.web3j.abi.datatypes.Array;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.StaticArray;
 
@@ -39,8 +42,15 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     private final Type type;
     private final boolean indexed;
 
+    private List<TypeReference<?>> innerTypes;
+
     protected TypeReference() {
         this(false);
+    }
+
+    protected TypeReference(List<TypeReference<?>> innerTypeReferences) {
+        this(false);
+        innerTypes = innerTypeReferences;
     }
 
     protected TypeReference(boolean indexed) {
@@ -61,6 +71,19 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
      */
     TypeReference getSubTypeReference() {
         return null;
+    }
+
+    public List<TypeReference<?>> getInnerTypeReferences() {
+        return innerTypes;
+    }
+
+    public List<TypeReference<?>> addInnerTypeReferences(TypeReference<?> typeReference) {
+        if(innerTypes == null) {
+            innerTypes = new ArrayList<>();
+        }
+
+        innerTypes.add(typeReference);
+        return innerTypes;
     }
 
     public int compareTo(TypeReference<T> o) {

--- a/abi/src/main/java/org/web3j/abi/TypeReference.java
+++ b/abi/src/main/java/org/web3j/abi/TypeReference.java
@@ -14,13 +14,11 @@ package org.web3j.abi;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.web3j.abi.datatypes.AbiTypes;
-import org.web3j.abi.datatypes.Array;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.StaticArray;
 
@@ -42,15 +40,15 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
     private final Type type;
     private final boolean indexed;
 
-    private List<TypeReference<?>> innerTypes;
+    protected List<TypeReference<?>> innerTypes;
 
     protected TypeReference() {
         this(false);
     }
 
-    protected TypeReference(List<TypeReference<?>> innerTypeReferences) {
-        this(false);
-        innerTypes = innerTypeReferences;
+    protected TypeReference(boolean indexed, List<TypeReference<?>> innerTypesIn) {
+        this(indexed);
+        this.innerTypes = innerTypesIn;
     }
 
     protected TypeReference(boolean indexed) {
@@ -69,21 +67,12 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
      *
      * @return the type wrapped by this Array TypeReference, or null if not Array
      */
-    TypeReference getSubTypeReference() {
+    public TypeReference getSubTypeReference() {
         return null;
     }
 
-    public List<TypeReference<?>> getInnerTypeReferences() {
-        return innerTypes;
-    }
-
-    public List<TypeReference<?>> addInnerTypeReferences(TypeReference<?> typeReference) {
-        if(innerTypes == null) {
-            innerTypes = new ArrayList<>();
-        }
-
-        innerTypes.add(typeReference);
-        return innerTypes;
+    public List<TypeReference<?>> getInnerTypes() {
+        return this.innerTypes;
     }
 
     public int compareTo(TypeReference<T> o) {
@@ -198,7 +187,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                 arrayWrappedType =
                         new TypeReference<DynamicArray>(indexed) {
                             @Override
-                            TypeReference getSubTypeReference() {
+                            public TypeReference getSubTypeReference() {
                                 return baseTr;
                             }
 
@@ -236,7 +225,7 @@ public abstract class TypeReference<T extends org.web3j.abi.datatypes.Type>
                         new TypeReference.StaticArrayTypeReference<StaticArray>(arraySizeInt) {
 
                             @Override
-                            TypeReference getSubTypeReference() {
+                            public TypeReference getSubTypeReference() {
                                 return baseTr;
                             }
 

--- a/abi/src/main/java/org/web3j/abi/Utils.java
+++ b/abi/src/main/java/org/web3j/abi/Utils.java
@@ -92,7 +92,7 @@ public class Utils {
     public static TypeReference<DynamicArray> getDynamicArrayTypeReference(Class parameter) {
         return new TypeReference<DynamicArray>() {
             @Override
-            TypeReference getSubTypeReference() {
+            public TypeReference getSubTypeReference() {
                 return TypeReference.create(parameter);
             }
         };

--- a/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/DynamicStruct.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class DynamicStruct extends DynamicArray<Type> implements StructType {
 
-    private final List<Class<Type>> itemTypes = new ArrayList<>();
+    public final List<Class<Type>> itemTypes = new ArrayList<>();
 
     public DynamicStruct(List<Type> values) {
         this(Type.class, values);

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -60,7 +60,7 @@ public class DefaultFunctionEncoderTest {
     }
 
     @Test
-    public void testArrayOfDynamicStruct() throws ClassNotFoundException {
+    public void testBuildEventOfArrayOfDynamicStruct() throws ClassNotFoundException {
         // The full event signature is
         //
         //     Stamp3(uint256 indexed stampId, address indexed caller, bool odd,

--- a/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/DefaultFunctionEncoderTest.java
@@ -60,49 +60,6 @@ public class DefaultFunctionEncoderTest {
     }
 
     @Test
-    public void testDynamicStructFix() throws ClassNotFoundException {
-        // Return data from 'testInputAndOutput' function of this contract
-        // https://sepolia.etherscan.io/address/0x009C10396226ECFE3E39b3f1AEFa072E37578e30#readContract
-        String returnedData =
-                "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000000b76616c75656265666f72650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000001320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000063078313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a76616c7565616674657200000000000000000000000000000000000000000000";
-
-        List<TypeReference<?>> MyStruct2Types = new ArrayList<>();
-        List<TypeReference<?>> MyStructTypes = new ArrayList<>();
-        List<TypeReference<?>> MyParameters = new ArrayList<>();
-
-        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
-        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
-
-        MyStructTypes.add(TypeReference.makeTypeReference("uint256"));
-        MyStructTypes.add(TypeReference.makeTypeReference("string"));
-        MyStructTypes.add(TypeReference.makeTypeReference("string"));
-        MyStructTypes.add(new TypeReference<DynamicStruct>(false, MyStruct2Types) {});
-
-        MyParameters.add(TypeReference.makeTypeReference("string"));
-        MyParameters.add(new TypeReference<DynamicStruct>(false, MyStructTypes) {});
-
-        MyParameters.add(TypeReference.makeTypeReference("string"));
-
-        List<Type> decodedData =
-                FunctionReturnDecoder.decode(returnedData, Utils.convert(MyParameters));
-
-        assertEquals(decodedData.get(0).getValue(), "valuebefore");
-
-        List<Type> structData = ((DynamicStruct) decodedData.get(1)).getValue();
-
-        assertEquals(structData.get(0).getValue(), BigInteger.valueOf(1));
-        assertEquals(structData.get(1).getValue(), "2");
-        assertEquals(structData.get(2).getValue(), "3");
-
-        List<Type> innerStructData = ((DynamicStruct) structData.get(3)).getValue();
-
-        assertEquals(innerStructData.get(0).getValue(), "1234");
-        assertEquals(innerStructData.get(1).getValue(), "0x1234");
-
-        assertEquals(decodedData.get(2).getValue(), "valueafter");
-    }
-
-    @Test
     public void testArrayOfDynamicStruct() throws ClassNotFoundException {
         // The full event signature is
         //

--- a/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -1319,31 +1319,48 @@ public class FunctionReturnDecoderTest {
     }
 
     @Test
-    public void testDynamicStructFix() throws ClassNotFoundException {
+    public void testDynamicStructWithAdditionalParametersReturn() throws ClassNotFoundException {
         // Return data from 'testInputAndOutput' function of this contract
         // https://sepolia.etherscan.io/address/0x009C10396226ECFE3E39b3f1AEFa072E37578e30#readContract
+        //        struct MyStruct {
+        //            uint256 value1;
+        //            string value2;
+        //            string value3;
+        //            MyStruct2 value4;
+        //        }
+        //
+        //        struct MyStruct2 {
+        //            string value1;
+        //            string value2;
+        //        }
+        //        function testInputAndOutput(MyStruct memory struc) external pure
+        //        returns(string memory valueBefore, MyStruct memory, string memory valueAfter) {
+        //
+        //            return ("valuebefore", mystruc, "valueafter");
+        //
+        //        }
         String returnedData =
                 "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000000b76616c75656265666f72650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000001320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000063078313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a76616c7565616674657200000000000000000000000000000000000000000000";
 
-        List<TypeReference<?>> MyStruct2Types = new ArrayList<>();
-        List<TypeReference<?>> MyStructTypes = new ArrayList<>();
-        List<TypeReference<?>> MyParameters = new ArrayList<>();
+        List<TypeReference<?>> myStruct2Types = new ArrayList<>();
+        List<TypeReference<?>> myStructTypes = new ArrayList<>();
+        List<TypeReference<?>> myParameters = new ArrayList<>();
 
-        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
-        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
+        myStruct2Types.add(TypeReference.makeTypeReference("string"));
+        myStruct2Types.add(TypeReference.makeTypeReference("string"));
 
-        MyStructTypes.add(TypeReference.makeTypeReference("uint256"));
-        MyStructTypes.add(TypeReference.makeTypeReference("string"));
-        MyStructTypes.add(TypeReference.makeTypeReference("string"));
-        MyStructTypes.add(new TypeReference<DynamicStruct>(false, MyStruct2Types) {});
+        myStructTypes.add(TypeReference.makeTypeReference("uint256"));
+        myStructTypes.add(TypeReference.makeTypeReference("string"));
+        myStructTypes.add(TypeReference.makeTypeReference("string"));
+        myStructTypes.add(new TypeReference<DynamicStruct>(false, myStruct2Types) {});
 
-        MyParameters.add(TypeReference.makeTypeReference("string"));
-        MyParameters.add(new TypeReference<DynamicStruct>(false, MyStructTypes) {});
+        myParameters.add(TypeReference.makeTypeReference("string"));
+        myParameters.add(new TypeReference<DynamicStruct>(false, myStructTypes) {});
 
-        MyParameters.add(TypeReference.makeTypeReference("string"));
+        myParameters.add(TypeReference.makeTypeReference("string"));
 
         List<Type> decodedData =
-                FunctionReturnDecoder.decode(returnedData, Utils.convert(MyParameters));
+                FunctionReturnDecoder.decode(returnedData, Utils.convert(myParameters));
 
         assertEquals(decodedData.get(0).getValue(), "valuebefore");
 

--- a/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.DynamicBytes;
+import org.web3j.abi.datatypes.DynamicStruct;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.StaticArray;
 import org.web3j.abi.datatypes.Type;
@@ -46,7 +47,8 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.<Type>emptyList(),
-                        Collections.singletonList(new TypeReference<Uint>() {}));
+                        Collections.singletonList(new TypeReference<Uint>() {
+                        }));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -61,7 +63,8 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "simple",
                         Arrays.asList(),
-                        Collections.singletonList(new TypeReference<Utf8String>() {}));
+                        Collections.singletonList(new TypeReference<Utf8String>() {
+                        }));
 
         List<Type> utf8Strings =
                 FunctionReturnDecoder.decode(
@@ -79,7 +82,8 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.emptyList(),
-                        Collections.singletonList(new TypeReference<Utf8String>() {}));
+                        Collections.singletonList(new TypeReference<Utf8String>() {
+                        }));
 
         List<Type> utf8Strings =
                 FunctionReturnDecoder.decode(
@@ -96,7 +100,9 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.<Type>emptyList(),
-                        Arrays.asList(new TypeReference<Uint>() {}, new TypeReference<Uint>() {}));
+                        Arrays.asList(new TypeReference<Uint>() {
+                        }, new TypeReference<Uint>() {
+                        }));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -113,10 +119,14 @@ public class FunctionReturnDecoderTest {
                         "function",
                         Collections.<Type>emptyList(),
                         Arrays.asList(
-                                new TypeReference<Utf8String>() {},
-                                new TypeReference<Utf8String>() {},
-                                new TypeReference<Utf8String>() {},
-                                new TypeReference<Utf8String>() {}));
+                                new TypeReference<Utf8String>() {
+                                },
+                                new TypeReference<Utf8String>() {
+                                },
+                                new TypeReference<Utf8String>() {
+                                },
+                                new TypeReference<Utf8String>() {
+                                }));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -144,8 +154,10 @@ public class FunctionReturnDecoderTest {
         List<TypeReference<Type>> outputParameters = new ArrayList<>(1);
         outputParameters.add(
                 (TypeReference)
-                        new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) {});
-        outputParameters.add((TypeReference) new TypeReference<Uint256>() {});
+                        new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) {
+                        });
+        outputParameters.add((TypeReference) new TypeReference<Uint256>() {
+        });
 
         List<Type> decoded =
                 FunctionReturnDecoder.decode(
@@ -177,7 +189,8 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.emptyList(),
-                        Collections.singletonList(new TypeReference<Uint>() {}));
+                        Collections.singletonList(new TypeReference<Uint>() {
+                        }));
 
         assertEquals(
                 FunctionReturnDecoder.decode("0x", function.getOutputParameters()),
@@ -190,7 +203,8 @@ public class FunctionReturnDecoderTest {
         String encoded = TypeEncoder.encodeNumeric(value);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(encoded, new TypeReference<Uint256>() {}),
+                FunctionReturnDecoder.decodeIndexedValue(encoded, new TypeReference<Uint256>() {
+                }),
                 (value));
     }
 
@@ -201,7 +215,8 @@ public class FunctionReturnDecoderTest {
         String hash = Hash.sha3(encoded);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(hash, new TypeReference<Utf8String>() {}),
+                FunctionReturnDecoder.decodeIndexedValue(hash, new TypeReference<Utf8String>() {
+                }),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -211,7 +226,8 @@ public class FunctionReturnDecoderTest {
         byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes32>() {}),
+                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes32>() {
+                }),
                 (new Bytes32(rawInputBytes)));
     }
 
@@ -221,19 +237,21 @@ public class FunctionReturnDecoderTest {
         byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput.substring(0, 34));
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes16>() {}),
+                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes16>() {
+                }),
                 (new Bytes16(rawInputBytes)));
     }
 
     @Test
     public void testDecodeIndexedDynamicBytesValue() {
-        DynamicBytes bytes = new DynamicBytes(new byte[] {1, 2, 3, 4, 5});
+        DynamicBytes bytes = new DynamicBytes(new byte[]{1, 2, 3, 4, 5});
         String encoded = TypeEncoder.encodeDynamicBytes(bytes);
         String hash = Hash.sha3(encoded);
 
         assertEquals(
                 FunctionReturnDecoder.decodeIndexedValue(
-                        hash, new TypeReference<DynamicBytes>() {}),
+                        hash, new TypeReference<DynamicBytes>() {
+                        }),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -247,7 +265,8 @@ public class FunctionReturnDecoderTest {
 
         assertEquals(
                 FunctionReturnDecoder.decodeIndexedValue(
-                        hash, new TypeReference<DynamicArray>() {}),
+                        hash, new TypeReference<DynamicArray>() {
+                        }),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -1262,8 +1281,10 @@ public class FunctionReturnDecoderTest {
         List outputParameters = new ArrayList<TypeReference<Type>>();
         outputParameters.addAll(
                 Arrays.asList(
-                        new TypeReference<StaticArray4<Utf8String>>() {},
-                        new TypeReference<StaticArray4<Uint256>>() {}));
+                        new TypeReference<StaticArray4<Utf8String>>() {
+                        },
+                        new TypeReference<StaticArray4<Uint256>>() {
+                        }));
 
         // tuple of (strings string[4]{"", "", "", ""}, ints int[4]{0, 0, 0, 0})
         String rawInput =
@@ -1315,5 +1336,50 @@ public class FunctionReturnDecoderTest {
                 Arrays.asList(
                         new AbiV2TestFixture.Qux(
                                 new AbiV2TestFixture.Bar(BigInteger.ONE, BigInteger.TEN), "data")));
+    }
+
+    @Test
+    public void testDynamicStructFix() throws ClassNotFoundException {
+        // Return data from 'testInputAndOutput' function of this contract
+        // https://sepolia.etherscan.io/address/0x009C10396226ECFE3E39b3f1AEFa072E37578e30#readContract
+        String returnedData =
+                "0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000260000000000000000000000000000000000000000000000000000000000000000b76616c75656265666f72650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000001320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000063078313233340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a76616c7565616674657200000000000000000000000000000000000000000000";
+
+        List<TypeReference<?>> MyStruct2Types = new ArrayList<>();
+        List<TypeReference<?>> MyStructTypes = new ArrayList<>();
+        List<TypeReference<?>> MyParameters = new ArrayList<>();
+
+        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
+        MyStruct2Types.add(TypeReference.makeTypeReference("string"));
+
+        MyStructTypes.add(TypeReference.makeTypeReference("uint256"));
+        MyStructTypes.add(TypeReference.makeTypeReference("string"));
+        MyStructTypes.add(TypeReference.makeTypeReference("string"));
+        MyStructTypes.add(new TypeReference<DynamicStruct>(false, MyStruct2Types) {
+        });
+
+        MyParameters.add(TypeReference.makeTypeReference("string"));
+        MyParameters.add(new TypeReference<DynamicStruct>(false, MyStructTypes) {
+        });
+
+        MyParameters.add(TypeReference.makeTypeReference("string"));
+
+        List<Type> decodedData =
+                FunctionReturnDecoder.decode(returnedData, Utils.convert(MyParameters));
+
+        assertEquals(decodedData.get(0).getValue(), "valuebefore");
+
+        List<Type> structData = ((DynamicStruct) decodedData.get(1)).getValue();
+
+        assertEquals(structData.get(0).getValue(), BigInteger.valueOf(1));
+        assertEquals(structData.get(1).getValue(), "2");
+        assertEquals(structData.get(2).getValue(), "3");
+
+        List<Type> innerStructData = ((DynamicStruct) structData.get(3)).getValue();
+
+        assertEquals(innerStructData.get(0).getValue(), "1234");
+        assertEquals(innerStructData.get(1).getValue(), "0x1234");
+
+        assertEquals(decodedData.get(2).getValue(), "valueafter");
     }
 }

--- a/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
+++ b/abi/src/test/java/org/web3j/abi/FunctionReturnDecoderTest.java
@@ -47,8 +47,7 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.<Type>emptyList(),
-                        Collections.singletonList(new TypeReference<Uint>() {
-                        }));
+                        Collections.singletonList(new TypeReference<Uint>() {}));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -63,8 +62,7 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "simple",
                         Arrays.asList(),
-                        Collections.singletonList(new TypeReference<Utf8String>() {
-                        }));
+                        Collections.singletonList(new TypeReference<Utf8String>() {}));
 
         List<Type> utf8Strings =
                 FunctionReturnDecoder.decode(
@@ -82,8 +80,7 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.emptyList(),
-                        Collections.singletonList(new TypeReference<Utf8String>() {
-                        }));
+                        Collections.singletonList(new TypeReference<Utf8String>() {}));
 
         List<Type> utf8Strings =
                 FunctionReturnDecoder.decode(
@@ -100,9 +97,7 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.<Type>emptyList(),
-                        Arrays.asList(new TypeReference<Uint>() {
-                        }, new TypeReference<Uint>() {
-                        }));
+                        Arrays.asList(new TypeReference<Uint>() {}, new TypeReference<Uint>() {}));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -119,14 +114,10 @@ public class FunctionReturnDecoderTest {
                         "function",
                         Collections.<Type>emptyList(),
                         Arrays.asList(
-                                new TypeReference<Utf8String>() {
-                                },
-                                new TypeReference<Utf8String>() {
-                                },
-                                new TypeReference<Utf8String>() {
-                                },
-                                new TypeReference<Utf8String>() {
-                                }));
+                                new TypeReference<Utf8String>() {},
+                                new TypeReference<Utf8String>() {},
+                                new TypeReference<Utf8String>() {},
+                                new TypeReference<Utf8String>() {}));
 
         assertEquals(
                 FunctionReturnDecoder.decode(
@@ -154,10 +145,8 @@ public class FunctionReturnDecoderTest {
         List<TypeReference<Type>> outputParameters = new ArrayList<>(1);
         outputParameters.add(
                 (TypeReference)
-                        new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) {
-                        });
-        outputParameters.add((TypeReference) new TypeReference<Uint256>() {
-        });
+                        new TypeReference.StaticArrayTypeReference<StaticArray<Uint256>>(2) {});
+        outputParameters.add((TypeReference) new TypeReference<Uint256>() {});
 
         List<Type> decoded =
                 FunctionReturnDecoder.decode(
@@ -189,8 +178,7 @@ public class FunctionReturnDecoderTest {
                 new Function(
                         "test",
                         Collections.emptyList(),
-                        Collections.singletonList(new TypeReference<Uint>() {
-                        }));
+                        Collections.singletonList(new TypeReference<Uint>() {}));
 
         assertEquals(
                 FunctionReturnDecoder.decode("0x", function.getOutputParameters()),
@@ -203,8 +191,7 @@ public class FunctionReturnDecoderTest {
         String encoded = TypeEncoder.encodeNumeric(value);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(encoded, new TypeReference<Uint256>() {
-                }),
+                FunctionReturnDecoder.decodeIndexedValue(encoded, new TypeReference<Uint256>() {}),
                 (value));
     }
 
@@ -215,8 +202,7 @@ public class FunctionReturnDecoderTest {
         String hash = Hash.sha3(encoded);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(hash, new TypeReference<Utf8String>() {
-                }),
+                FunctionReturnDecoder.decodeIndexedValue(hash, new TypeReference<Utf8String>() {}),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -226,8 +212,7 @@ public class FunctionReturnDecoderTest {
         byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput);
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes32>() {
-                }),
+                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes32>() {}),
                 (new Bytes32(rawInputBytes)));
     }
 
@@ -237,21 +222,19 @@ public class FunctionReturnDecoderTest {
         byte[] rawInputBytes = Numeric.hexStringToByteArray(rawInput.substring(0, 34));
 
         assertEquals(
-                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes16>() {
-                }),
+                FunctionReturnDecoder.decodeIndexedValue(rawInput, new TypeReference<Bytes16>() {}),
                 (new Bytes16(rawInputBytes)));
     }
 
     @Test
     public void testDecodeIndexedDynamicBytesValue() {
-        DynamicBytes bytes = new DynamicBytes(new byte[]{1, 2, 3, 4, 5});
+        DynamicBytes bytes = new DynamicBytes(new byte[] {1, 2, 3, 4, 5});
         String encoded = TypeEncoder.encodeDynamicBytes(bytes);
         String hash = Hash.sha3(encoded);
 
         assertEquals(
                 FunctionReturnDecoder.decodeIndexedValue(
-                        hash, new TypeReference<DynamicBytes>() {
-                        }),
+                        hash, new TypeReference<DynamicBytes>() {}),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -265,8 +248,7 @@ public class FunctionReturnDecoderTest {
 
         assertEquals(
                 FunctionReturnDecoder.decodeIndexedValue(
-                        hash, new TypeReference<DynamicArray>() {
-                        }),
+                        hash, new TypeReference<DynamicArray>() {}),
                 (new Bytes32(Numeric.hexStringToByteArray(hash))));
     }
 
@@ -1281,10 +1263,8 @@ public class FunctionReturnDecoderTest {
         List outputParameters = new ArrayList<TypeReference<Type>>();
         outputParameters.addAll(
                 Arrays.asList(
-                        new TypeReference<StaticArray4<Utf8String>>() {
-                        },
-                        new TypeReference<StaticArray4<Uint256>>() {
-                        }));
+                        new TypeReference<StaticArray4<Utf8String>>() {},
+                        new TypeReference<StaticArray4<Uint256>>() {}));
 
         // tuple of (strings string[4]{"", "", "", ""}, ints int[4]{0, 0, 0, 0})
         String rawInput =
@@ -1355,12 +1335,10 @@ public class FunctionReturnDecoderTest {
         MyStructTypes.add(TypeReference.makeTypeReference("uint256"));
         MyStructTypes.add(TypeReference.makeTypeReference("string"));
         MyStructTypes.add(TypeReference.makeTypeReference("string"));
-        MyStructTypes.add(new TypeReference<DynamicStruct>(false, MyStruct2Types) {
-        });
+        MyStructTypes.add(new TypeReference<DynamicStruct>(false, MyStruct2Types) {});
 
         MyParameters.add(TypeReference.makeTypeReference("string"));
-        MyParameters.add(new TypeReference<DynamicStruct>(false, MyStructTypes) {
-        });
+        MyParameters.add(new TypeReference<DynamicStruct>(false, MyStructTypes) {});
 
         MyParameters.add(TypeReference.makeTypeReference("string"));
 

--- a/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
+++ b/codegen/src/test/java/org/web3j/codegen/SolidityFunctionWrapperGeneratorTest.java
@@ -246,7 +246,10 @@ public class SolidityFunctionWrapperGeneratorTest extends TempFileProvider {
     @Test
     public void testStaticArrayOfStructsInStructGeneration() throws Exception {
         testCodeGeneration(
-                "staticarrayofstructsinstruct", "StaticArrayOfStructsInStruct", JAVA_TYPES_ARG, false);
+                "staticarrayofstructsinstruct",
+                "StaticArrayOfStructsInStruct",
+                JAVA_TYPES_ARG,
+                false);
     }
 
     @Test

--- a/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
+++ b/core/src/main/java/org/web3j/protocol/core/methods/response/AbiDefinition.java
@@ -277,9 +277,9 @@ public class AbiDefinition {
 
         public String structIdentifier() {
             return ((internalType == null ? type : internalType.isEmpty() ? type : internalType)
-                            + components.stream()
-                                    .map(NamedType::structIdentifier)
-                                    .collect(Collectors.joining()));
+                    + components.stream()
+                            .map(NamedType::structIdentifier)
+                            .collect(Collectors.joining()));
         }
 
         public int nestedness() {


### PR DESCRIPTION
- **Updated TypeReference object to support nested types to support truly dynamic stucts.**
- **Support decoding of DynamicArray of DynamicStruct (with corresponding unit test). Change visibility of TypeReference's innerTypes and getSubTypeReference() to protected/public to allow for overriding in anonymous classes. Redo naming of some innerType-specific functions in TypeDecoder to minimize code diffs.**

### What does this PR do?
This PR builds off of the PR originally created by calmacfadden at https://github.com/hyperledger/web3j/pull/2023.

### Where should the reviewer start?
* Look in TypeDecoder.java, with attention to the decodeDynamicParameterFromStructWithTypeReference() and
decodeDynamicStructElementsFromInnerTypes(). Note that the Ctor() version of functions from PR 2023 have been
renamed to omit the Ctor so as to match the name in the main branch and reduce code diffs.

* The unit test testArrayOfDynamicStruct() provides an example of decoding an array of dynamic structs (uint256,bool,string)[]
based on a transaction from the Treasure Ruby testnet.

* I've taken some stylistic liberty by renaming TypeReference.innerTypeReferences() to TypeReferences.innerTypes().

* I've changed the scope of some fields in TypeReference from private to protected/public to allow for creating the
anonymous DynamicArray class seen in testArrayOfDynamicStruct().

### Why is it needed?
As with PR 2023, it would be useful to decode dynamic structs without having to explicitly define a corresponding class.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.
