### PR TITLE
Bug fix for BytesType.bytes32PaddedLength

### DIFF
--- a/abi/src/main/java/org/web3j/abi/datatypes/BytesType.java
+++ b/abi/src/main/java/org/web3j/abi/datatypes/BytesType.java
@@ -27,9 +27,13 @@ public abstract class BytesType implements Type<byte[]> {
 
     @Override
     public int bytes32PaddedLength() {
-        return value.length <= 32
-                ? MAX_BYTE_LENGTH
-                : (value.length / MAX_BYTE_LENGTH + 1) * MAX_BYTE_LENGTH;
+        if (value.length < MAX_BYTE_LENGTH) {
+            return MAX_BYTE_LENGTH;
+        } else if (value.length % MAX_BYTE_LENGTH == 0) {
+            return value.length;
+        } else {
+            return (value.length / MAX_BYTE_LENGTH + 1) * MAX_BYTE_LENGTH;
+        }
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Bug fix for BytesType.bytes32PaddedLength

### Where should the reviewer start?
#2080 

### Why is it needed?
`BytesType.bytes32PaddedLength()` returns incorrect value for lengths greater than 32 and multiples of 32.

[BytesType::bytes32PaddedLength‎](https://github.com/hyperledger/web3j/blob/main/abi/src/main/java/org/web3j/abi/datatypes/BytesType.java#L29)
```java
    @Override
    public int bytes32PaddedLength() {
        return value.length <= 32
                ? MAX_BYTE_LENGTH
                : (value.length / MAX_BYTE_LENGTH + 1) * MAX_BYTE_LENGTH;
    }
```
In case of the `value.length` is 64, 96, 128, ...
It should return 64, 96, 128, ...
However, the results are 96, 128, 160, ...

The corrected code is as follows:
```java
    @Override
    public int bytes32PaddedLength() {
        if (value.length < MAX_BYTE_LENGTH) {
            return MAX_BYTE_LENGTH;
        } else if (value.length % MAX_BYTE_LENGTH == 0) {
            return value.length;
        } else {
            return (value.length / MAX_BYTE_LENGTH + 1) * MAX_BYTE_LENGTH;
        }
    }
```

## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.

fix #2080 