### PR TITLE
Web3j extends AutoClosable Interface

### DIFF
--- a/core/src/main/java/org/web3j/protocol/Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/Web3j.java
@@ -21,7 +21,7 @@ import org.web3j.protocol.core.JsonRpc2_0Web3j;
 import org.web3j.protocol.rx.Web3jRx;
 
 /** JSON-RPC Request object building factory. */
-public interface Web3j extends Ethereum, Web3jRx, Batcher, BlobFee {
+public interface Web3j extends Ethereum, Web3jRx, Batcher, BlobFee, AutoCloseable {
 
     /**
      * Construct a new Web3j instance.

--- a/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
+++ b/core/src/main/java/org/web3j/protocol/core/JsonRpc2_0Web3j.java
@@ -906,4 +906,9 @@ public class JsonRpc2_0Web3j implements Web3j {
         }
         return output.divide(BLOB_BASE_FEE_UPDATE_FRACTION);
     }
+
+    @Override
+    public void close() throws Exception {
+        this.shutdown();
+    }
 }

--- a/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
+++ b/core/src/test/java/org/web3j/protocol/core/JsonRpc2_0Web3jTest.java
@@ -37,8 +37,7 @@ public class JsonRpc2_0Web3jTest {
     public void testStopExecutorOnShutdown() throws Exception {
         web3j.shutdown();
 
-        verify(scheduledExecutorService).shutdown();
-        verify(service).close();
+        verifyServicesClosed();
     }
 
     @Test
@@ -51,5 +50,16 @@ public class JsonRpc2_0Web3jTest {
 
                     web3j.shutdown();
                 });
+    }
+
+    @Test
+    public void shouldShutdownOnAutoClose() throws Exception {
+        try (Web3j web3j = Web3j.build(service, 10, scheduledExecutorService)) {}
+        verifyServicesClosed();
+    }
+
+    private void verifyServicesClosed() throws IOException {
+        verify(scheduledExecutorService).shutdown();
+        verify(service).close();
     }
 }


### PR DESCRIPTION
### What does this PR do?
Makes Web3j autoclosable to use it in `try-with-resources` blocks, as wished for in #1983 .

### Where should the reviewer start?
At the Web3j Interface, extending the AutoClosable Interface.

### Why is it needed?
So users do not forget to close the Web3j instance.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [ ] I've added a changelog entry if necessary.